### PR TITLE
FIX: Resolve AttributeError for queued synthesis

### DIFF
--- a/audiblez/core.py
+++ b/audiblez/core.py
@@ -141,7 +141,14 @@ def main(file_path, voice, pick_manually, speed, output_folder='.',
     for i, chapter in enumerate(selected_chapters, start=1):
         if max_chapters and i > max_chapters: break
         text = chapter.extracted_text
-        xhtml_file_name = chapter.get_name().replace(' ', '_').replace('/', '_').replace('\\', '_')
+        # Use chapter.title if get_name() is not available (for ChapterForCore objects from queue)
+        if hasattr(chapter, 'get_name'):
+            original_name = chapter.get_name()
+        elif hasattr(chapter, 'title'):
+            original_name = chapter.title
+        else:
+            original_name = f"chapter_{i}" # Fallback if neither is present
+        xhtml_file_name = original_name.replace(' ', '_').replace('/', '_').replace('\\', '_')
         chapter_wav_path = Path(output_folder) / filename.replace(extension, f'_chapter_{i}_{voice}_{xhtml_file_name}.wav')
         chapter_wav_files.append(chapter_wav_path)
         if Path(chapter_wav_path).exists():


### PR DESCRIPTION
Modify core.py to handle ChapterForCore objects from the UI queue. These objects do not have a get_name() method. The code now checks for get_name() and falls back to using the chapter.title attribute, with a generic name as a final fallback. This allows chapters from the queue to be processed without an AttributeError.